### PR TITLE
fix: create account name null

### DIFF
--- a/app/Controller/Pages/Account/Create.php
+++ b/app/Controller/Pages/Account/Create.php
@@ -41,7 +41,7 @@ class Create extends Base{
     public static function createAccount($request)
     {
         $postVars = $request->getPostVars();
-		$account_name = $postVars['accname'] ?? '';
+        $account_name = $postVars['accname'] ?? '';
         $account_email = $postVars['email'] ?? '';
         $account_password1 = $postVars['password1'] ?? '';
         $account_password2 = $postVars['password2'] ?? '';

--- a/app/Controller/Pages/Account/Create.php
+++ b/app/Controller/Pages/Account/Create.php
@@ -41,6 +41,7 @@ class Create extends Base{
     public static function createAccount($request)
     {
         $postVars = $request->getPostVars();
+		$account_name = $postVars['accname'] ?? '';
         $account_email = $postVars['email'] ?? '';
         $account_password1 = $postVars['password1'] ?? '';
         $account_password2 = $postVars['password2'] ?? '';
@@ -50,6 +51,15 @@ class Create extends Base{
         $character_world = $postVars['world'] ?? '';
         $account_agreeagreements = $postVars['agreeagreements'] ?? '';
 
+        if(!filter_var($account_name, FILTER_SANITIZE_SPECIAL_CHARS)){
+            return self::getCreateAccount($request, 'This email address has an invalid format. Please enter a correct email address!');
+        }
+        $filter_acc_name = filter_var($account_name, FILTER_SANITIZE_SPECIAL_CHARS);
+        $verifyAccAccount = EntityPlayer::getAccount('name = "'.$account_name.'"')->fetchObject();
+        if(!empty($verifyAccAccount)){
+            return self::getCreateAccount($request, 'This Account name is already in use!');
+        }
+		
         if(!filter_var($account_email, FILTER_VALIDATE_EMAIL)){
             return self::getCreateAccount($request, 'This email address has an invalid format. Please enter a correct email address!');
         }
@@ -119,7 +129,7 @@ class Create extends Base{
         }
 
         $account = [
-            'name' => '',
+            'name' => $filter_acc_name,
             'password' => $convertPassword,
             'email' => $filter_email,
             'page_access' => '0',

--- a/resources/view/pages/account/createaccount.html.twig
+++ b/resources/view/pages/account/createaccount.html.twig
@@ -208,6 +208,17 @@ ServerList.push(new Array('{{ world.name }}', '{{ world.location_initial }}', '{
 																<div class="TableContentContainer">
 																	<table class="TableContent" width="100%" style="border:1px solid #faf0d7;">
 																		<tbody>
+																		<tr>
+																				<td class="LabelV150">
+																					<span id="accname_label">Account Name:</span>
+																				</td>
+																				<td><input id="accname" name="accname" class="CreateAccountFormInput" maxlength="50"><div id="accname_indicator" class="InputIndicatorNotOK"></div>
+																				</td>
+																			</tr>
+																			<tr>
+																				<td></td>
+																				<td><span id="accname_errormessage" class="FormFieldError" style="display: none;">Please enter your account name!</span></td>
+																			</tr>
 																			<tr>
 																				<td class="LabelV150">
 																					<span id="email_label">Email Address:</span>


### PR DESCRIPTION
### Solving problems with Account Name null

Fix a problem where canaryacc didn't used the Account Name to input in SQL table 'accounts', and started to create accounts without Name Account. 

Account name is a key field and need to be unique, so creating accounts in blank would trigger an error.
`ERROR: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '' for key 'name'`